### PR TITLE
fix git repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Paolo Chiodi (https://github.com/paolochiodi)",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/seneca-labs/seneca-zipkin-tracer.git"
+    "url": "git+https://github.com/senecajs-labs/seneca-zipkin-tracer.git"
   },
   "scripts": {
     "test": "lab test/*.test.js -r console -L -t 80 -c -v",


### PR DESCRIPTION
Make everyone can use `npm repo seneca-zipkin-tracer` to access the github repo page.